### PR TITLE
Fix README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The PHP version to be installed. Any [currently-supported PHP major version](htt
     - hosts: webservers
     
       vars:
-        php_version: 7.1
+        php_version: '7.1'
     
       roles:
         - role: geerlingguy.repo-remi


### PR DESCRIPTION
php_version needs to be a String otherwise Ansible will skip the repo enabling for such version.