### PR TITLE
Simplify purge task fixing odd apt resolve solutions

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -45,7 +45,7 @@
     purge: yes
     force: yes
   when: "'php' + php_version not in item"
-  with_flattened:
-    - "{{ php_packages|regex_replace('php' + php_version, 'php5.6') }}"
-    - "{{ php_packages|regex_replace('php' + php_version, 'php7.0') }}"
-    - "{{ php_packages|regex_replace('php' + php_version, 'php7.1') }}"
+  with_items:
+    - php5.6-common
+    - php7.0-common
+    - php7.1-common


### PR DESCRIPTION
See https://github.com/beetboxvm/beetbox/issues/438#issuecomment-330110735

Also read my comments above about how this fixes the encountered issue when `php-fpm` for some reason causes the APT resolver to trigger package upgrades during the purge task.

The only issue with this is if there are PHP packages that do not depend on `php-common`. I don't think there are any such packages but we might need to look into it more to verify.