### PR TITLE
Adds apt cache update before installing dependencies

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,4 +1,7 @@
 ---
+- name: Update apt cache.
+  apt: update_cache=yes cache_valid_time=86400
+
 - name: Set the correct opcache filename (Ubuntu/Debian).
   set_fact:
     php_opcache_conf_filename: "10-opcache.ini"


### PR DESCRIPTION
The task `Add dependencies for PHP versions (Debian).` is failing when the role `ansible-role-php-versions` is the first one to be run in a playbook since apt cache has never been run.