### PR TITLE
Fix #20 : role_path instead of relative path

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,8 +2,8 @@
 - name: Include OS-specific variables.
   include_vars: "{{ item }}"
   with_fileglob:
-    - "../vars/{{ ansible_os_family }}.yml"
-    - "../vars/{{ ansible_os_family }}-php{{ php_version }}.yml"
+    - "{{role_path}}/vars/{{ ansible_os_family }}.yml"
+    - "{{role_path}}/vars/{{ ansible_os_family }}-php{{ php_version }}.yml"
 
 - name: Define PHP variables.
   set_fact: "{{ item.key }}={{ hostvars[inventory_hostname][item.value] }}"


### PR DESCRIPTION
Correct the relative path to be able to use the role with an "include_role".
Without this fix, the files are not found when we include this role inside another one with "include_role"

Regards,