### PR TITLE
Added php 7.3 to list of version to purge

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -52,4 +52,5 @@
     - php7.0-common
     - php7.1-common
     - php7.2-common
+    - php7.3-common
   when: "'php' + php_version not in item"


### PR DESCRIPTION
This issue was found because one of the packages we were using had php 7.3 as a recommended package and the php_install_recommends flag was set to true in: https://github.com/geerlingguy/ansible-role-php/blob/master/defaults/main.yml#L11

There's probably a better way to purge unwanted versions in the future, as this would need to be updated for every PHP release.