### PR TITLE
Fix apt module loop to avoid deprecation notices

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -46,14 +46,16 @@
 # PHP package purges.
 - name: Purge PHP version packages.
   apt:
-    name: "{{ item }}"
+    name: "{{ __php_versions_debian |
+              reject('search', 'php' ~ php_version) |
+              list }}"
     state: absent
     purge: true
     force: true
-  with_items:
-    - php5.6-common
-    - php7.0-common
-    - php7.1-common
-    - php7.2-common
-    - php7.3-common
-  when: "'php' + php_version not in item"
+#### Add to vars/Debian.yml
+__php_versions_debian:
+  - php5.6-common
+  - php7.0-common
+  - php7.1-common
+  - php7.2-common
+  - php7.3-common


### PR DESCRIPTION
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items
and specifying `name: "{{ item }}"`, please use `name: ['php5.6-common',
'php7.0-common', 'php7.1-common', 'php7.2-common', 'php7.3-common']` and remove
the loop. This feature will be removed in version 2.11. Deprecation warnings
can be disabled by setting deprecation_warnings=False in ansible.cfg.