### PR TITLE
Under RedHat enable codeready-builder repository

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -21,6 +21,7 @@
 
   - name: Enable DNF module for CentOS 8+.
     shell: |
+      dnf config-manager --set-enabled codeready-builder-for-rhel-8-rhui-rpms
       dnf config-manager --set-enabled PowerTools
       dnf module enable -y php:remi-{{ php_version }}
     args:


### PR DESCRIPTION
On RedHat, after installing EPEL there is no PowerTools repository. Packages that normally are located in PowerTools can be found in the codeready-builder repository.
---

I've encountered this issue today while configuring a RedHat 8.2 instance on AWS. The error I've encountered

```
TASK geerlingguy.php : Ensure PHP packages are ******************************************************
fatal: [x.x.x.x]: FAILED! => {"changed": false, "failures": [], "msg": "Depsolve Error occured: \n
Problem: cannot install the best candidate for the job\n - nothing provides libedit-devel(x86-64)
needed by php-devel-7.3.18-1.el8.remi.x86_64", "rc": 1, "results": []}
```

While on CentOS that specific package (a dependency of `php-devel`) is located in the PowerTools repository, on RedHat it's located in the codeready-builder repository.

Also  see https://fedoraproject.org/wiki/EPEL#Quickstart