### PR TITLE
Fix php 7.4 not purged on debian

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -41,3 +41,4 @@ __php_packages:
 php_versions_debian:
   - php7.2-common
   - php7.3-common
+  - php7.4-common


### PR DESCRIPTION
Ahoy @geerlingguy! Long time, I hope you're doing well.

We ran into https://github.com/geerlingguy/drupal-vm/issues/2076 at work and I found the cause is that drupal-vm box now comes with php 7.4 preinstalled which isn't purged.

P.S. sorry for not being around more to help. Real life happened and I'm truly amazed at how you can keep up your Open Source contributions as much as you do. Thanks again