### PR TITLE
fix: Unusable php_packages variable

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,8 +8,8 @@
 - name: Define PHP variables.
   set_fact: "{{ item.key }}={{ lookup('vars', item.value) }}"
   when:
-    - hostvars[inventory_hostname][item.key] is undefined
-    - hostvars[inventory_hostname][item.value] is defined
+    - vars[item.key] is undefined
+    - vars[item.value] is defined
   with_dict:
     php_conf_paths: __php_conf_paths
     php_extension_conf_paths: __php_extension_conf_paths


### PR DESCRIPTION
It was impossible to set php_packages variable from a playbook when
using geerlingguy.php with geerlingguy.php-versions roles.

Also see issue #46 and PR #39 