### PR TITLE
Yum repoid of Power Tools has changed from PowerTools to powertools

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -21,7 +21,7 @@
 
   - name: Enable DNF module for CentOS 8+.
     shell: |
-      dnf config-manager --set-enabled PowerTools
+      dnf config-manager --set-enabled powertools
       dnf module enable -y php:remi-{{ php_version }}
     args:
       warn: false


### PR DESCRIPTION
```
TASK [ansible-role-certbot : Enable DNF module for CentOS 8+.] ********************************************************************************************************
fatal: [gcp04webimt01d]: FAILED! => {"changed": false, "cmd": "dnf config-manager --set-enabled PowerTools\n", "delta": "0:00:00.291549", "end": "2021-02-16 20:31:26.374256", "msg": "non-zero return code", "rc": 1, "start": "2021-02-16 20:31:26.082707", "stderr": "Error: No matching repo to modify: PowerTools.", "stderr_lines": ["Error: No matching repo to modify: PowerTools."], "stdout": "", "stdout_lines": []}
```

Ref.:
- https://wiki.centos.org/Manuals/ReleaseNotes/CentOS8.2011#Major_Changes
- https://github.com/geerlingguy/ansible-role-certbot/issues/143
