### PR TITLE
Added Ondřej Surý GPG key ID for Debian repo

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -24,6 +24,7 @@
 - name: Add Ondrej Sury's apt key (Debian).
   apt_key:
     url: https://packages.sury.org/php/apt.gpg
+    id: 15058500A0235D97F5D10063B188E2B695BD4743
     state: present
   when: ansible_distribution == "Debian"
 


### PR DESCRIPTION
This commit adds the new key ID for the Debian repo of Ondřej Surý
to ensure the GPG key won't be downloaded by the apt_key module if
it's already installed on the system.

This modification is made for systems behind several firewalls or
filtering proxies on which the key is pre-deployed and when the
Ansible module doesn't work well with proxy env vars (eg. apt_key)

See https://github.com/geerlingguy/ansible-role-php-versions/issues/54