### PR TITLE
ci: fixed ansible-lint errors and warnings

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,3 +3,14 @@ skip_list:
   - 'risky-shell-pipe'
   - 'no-handler'
   - 'role-name'
+
+exclude_paths:
+  - .cache/
+  - .github/
+  # Lint confuses this with a Play and says "'src' is not a valid attribute for a Play"
+  - molecule/default/requirements.yml
+
+mock_roles:
+  - geerlingguy.repo-remi
+  - geerlingguy.php_versions
+  - geerlingguy.php

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,12 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install yamllint
+        run: pip3 install yamllint ansible ansible-lint
 
       - name: Lint code.
         run: |
           yamllint .
+          ansible-lint
 
   molecule:
     name: Molecule

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,4 +35,6 @@ jobs:
         run: pip3 install ansible-base
 
       - name: Trigger a new import on Galaxy.
-        run: ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }} $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)
+        run: |
+          ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }} \
+          $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.retry
+# Ignore ansible-lint cache
+/.cache


### PR DESCRIPTION
- fixed: error "syntax-check 'src' is not a valid attribute for a Play";
- fixed: error "internal-error the role 'geerlingguy.repo-remi' was not
  found
  in ...";
- fixed: warning "[line-length] line too long (173 > 120 characters)".

P.S.: This is updated and squashed version of PR #61