### PR TITLE
modules need to be reset before enabling another one

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -28,6 +28,7 @@
   - name: Enable DNF module for CentOS 8+.
     shell: |
       dnf config-manager --set-enabled powertools
+      dnf module reset -y php
       dnf module enable -y php:remi-{{ php_version }}
     args:
       warn: false


### PR DESCRIPTION
When trying to upgrade a previous version the enabled module needs to be reset.