### PR TITLE
Use CodeReady Builder repo on RHEL 8 — fixes #72

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -25,12 +25,22 @@
       name: dnf-plugins-core
       state: present
 
-  - name: Enable DNF module for CentOS 8+.
+  - name: Enable PowerTools for CentOS 8+ (& other RHEL rebuilds, but not RHEL).
     shell: |
       dnf config-manager --set-enabled powertools
-      dnf module enable -y php:remi-{{ php_version }}
     args:
       warn: false
+    when: ansible_distribution != 'RedHat'
+
+  - name: Enable CodeReady Builder repo for RHEL 8
+    community.general.rhsm_repository:
+      name: codeready-builder-for-rhel-8-x86_64-rpms
+      state: enabled
+    when: ansible_distribution == 'RedHat'
+
+  - name: Enable Remi PHP module for EL distributions
+    shell: |
+      dnf module enable -y php:remi-{{ php_version }}
     register: dnf_module_enable
     changed_when: "'Nothing to do' not in dnf_module_enable.stdout"
 


### PR DESCRIPTION
Trying to enable the PowerTools DNF module on Red Hat Enterprise Linux 8 fails with `Error: No matching repo to modify: PowerTools.` On RHEL, the PowerTools repo content is known as "Red Hat CodeReady Linux Builder for RHEL 8", and can be enabled with `subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms`.
See also: https://access.redhat.com/discussions/5417621

This PR does just that when the target OS distribution is RHEL, and only enables PowerTools for non-Red Hat EL rebuilds (CentOS, etc).