### PR TITLE
added support for php 8.2, removed support for php 8.0, using php 8.2…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       matrix:
         include:
-          # Default PHP version (8.1).
+          # Default PHP version (8.2).
           - distro: rockylinux8
             playbook: converge.yml
           - distro: centos7
@@ -51,13 +51,13 @@ jobs:
           - distro: debian10
             playbook: converge.yml
 
-          # PHP 8.0.
+          # PHP 8.1.
           - distro: rockylinux8
-            playbook: 8.0.yml
+            playbook: 8.1.yml
           - distro: ubuntu1804
-            playbook: 8.0.yml
+            playbook: 8.1.yml
           - distro: debian10
-            playbook: 8.0.yml
+            playbook: 8.1.yml
 
           # PHP 7.4.
           - distro: rockylinux8

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ N/A
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
-    php_version: '8.1'
+    php_version: '8.2'
 
-The PHP version to be installed. Any [currently-supported PHP major version](http://php.net/supported-versions.php) is a valid option (e.g. `7.4`, `8.0`, or `8.1`).
+The PHP version to be installed. Any [currently-supported PHP major version](http://php.net/supported-versions.php) is a valid option (e.g. `8.1` or `8.2`).
 
     php_versions_install_recommends: false
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # The PHP version to be installed.
-php_version: '8.1'
+php_version: '8.2'
 
 # For Debian OSes only.
 php_versions_install_recommends: false

--- a/molecule/default/8.1.yml
+++ b/molecule/default/8.1.yml
@@ -5,7 +5,7 @@
 
   vars:
     php_enable_webserver: false
-    php_version: '8.0'
+    php_version: '8.1'
 
   pre_tasks:
     - name: Update apt cache.

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,25 +1,17 @@
 ---
-# TODO: PHP 7.2 support will be removed soon. This is only being left in here as
-# a convenience for legacy PHP 7.2 users.
-- name: Enable remi repo for PHP 7.2.
-  set_fact: php_enablerepo="remi,remi-php72"
-  when: php_version == "7.2"
-
-- name: Enable remi repo for PHP 7.3.
-  set_fact: php_enablerepo="remi,remi-php73"
-  when: php_version == "7.3"
-
+# TODO: PHP 7.4 support reached EOL. This is only being left in here as
+# a convenience for legacy PHP 7.4 users.
 - name: Enable remi repo for PHP 7.4.
   set_fact: php_enablerepo="remi,remi-php74"
   when: php_version == "7.4"
 
-- name: Enable remi repo for PHP 8.0.
-  set_fact: php_enablerepo="remi,remi-php80"
-  when: php_version == "8.0"
-
 - name: Enable remi repo for PHP 8.1.
   set_fact: php_enablerepo="remi,remi-php81"
   when: php_version == "8.1"
+
+- name: Enable remi repo for PHP 8.2.
+  set_fact: php_enablerepo="remi,remi-php81"
+  when: php_version == "8.2"
 
 # See: https://github.com/ansible/ansible/issues/64852
 - block:

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -39,9 +39,9 @@ __php_packages:
   - "php{{ php_version }}-yaml"
 
 php_versions_debian:
-  # TODO: PHP 7.2 support will be removed soon. This is only being left in here as
-  # a convenience for legacy PHP 7.2 users.
-  - php7.2-common
-  - php7.3-common
+  # TODO: PHP 7.4 support EOL. This is only being left in here as
+  # a convenience for legacy PHP 7.4 users.
   - php7.4-common
   - php8.0-common
+  - php8.1-common
+  - php8.2-common


### PR DESCRIPTION
During setup I noticed there is no php 8.2 support, also I would encourage users to install 8.1 or 8.2 since 8.0 is on LTS.

Furthermore I would suggest dropping php 7.4 completely since it reached EOL past month but I left it in there for legacy users