### PR TITLE
fix: debian vagrant box error for dirmngr install

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -7,6 +7,7 @@
   apt:
     name: dirmngr
     state: present
+    update_cache: yes
 
 - name: Add repository for PHP versions (Ubuntu).
   apt_repository: repo='ppa:ondrej/php'


### PR DESCRIPTION
Thank for your great work.

I found a bug when I use the role with the debian vagrant box (bullseye and bookworm). Apt cache isn't update by defaultin the box and the role stop with this message during dirmngr install :

> TASK [geerlingguy.php-versions : Ensure dirmngr is installed (gnupg dependency).] ***
fatal: [medshakeehr]: FAILED! => {"changed": false, "msg": "No package matching 'dirmngr' is available"}

My fix correct this behavior.