### PR TITLE
fix: require user confirmation to delete other php version in Debian

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,7 @@ php_version: '8.3'
 
 # For Debian OSes only.
 php_versions_install_recommends: false
+
+# Purge others version need user confirmation, default to false (no delete)
+# if auto delete, causing break in the existing service which depend to other version
+php_purge_other_version: false

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -49,6 +49,7 @@
     purge: true
     force: true
   register: php_version_purge
+  when: php_purge_other_version
 
 - name: Also purge php-common package if any versions were just purged.
   apt:
@@ -56,4 +57,4 @@
     state: absent
     purge: true
     force: true
-  when: php_version_purge.changed | bool
+  when: php_version_purge.changed | bool and php_purge_other_version


### PR DESCRIPTION
## Description

By auto delete another version from the machine, it causing existing service which depend to the version break and system down. Better if the purge mechanism require to confirm manually from executor (user) instead.

### Example Case

We have legacy service running with PHP 7.x fpm, depend to binary /usr/sbin/php-fpm7.2 running under systemd with command below:

```sh
.......................................................
.......................................................
[Service]
Type=notify
ExecStart=/usr/sbin/php-fpm7.0 --nodaemonize --fpm-config /etc/php/7.0/fpm/pool.d/example.conf --pid /run/php/php7.0-example.pid
.......................................................
.......................................................
```

When new service with newest PHP binary dependency coming, require devOps to install the binary, by using this roles the previous binary will be removed automatically in the task `Purge PHP version packages (besides the currently chosen php_version).`. Then when the legacy service owner deploy their service, it will break.

Powered by [dPanel](https://cloud.terpusat.com/)